### PR TITLE
Add prebuilt swift static framework rule example

### DIFF
--- a/prebuilt_swift_static_framework/README.md
+++ b/prebuilt_swift_static_framework/README.md
@@ -1,0 +1,27 @@
+# prebuilt_swift_static_framework
+
+This is a macro & rule to build multi-architecture (fat) static
+frameworks from Swift sources.
+
+This example could be updated based on your use case.
+
+## Usage
+
+You need to include
+[rules_swift](https://github.com/bazelbuild/rules_swift) in your
+WORKSPACE, then in a BUILD file:
+
+```python
+prebuilt_swift_static_framework(
+    name = "Whatever",
+    srcs = glob(["path/to/sources/*.swift"]),
+    deps = [":SomeDependency"],
+)
+```
+
+If you omit `srcs`, this macro defaults to `Sources/**/*.swift`. This
+macro doesn't currently support resources, but could be updated to do
+so. Internally this rule creates a `swift_library` and compiles it for
+all the architectures passed with `--ios_multi_cpus`. If you want to
+re-use this same `swift_library` you could make the
+`_prebuilt_swift_static_framework` public, and use it directly.

--- a/prebuilt_swift_static_framework/README.md
+++ b/prebuilt_swift_static_framework/README.md
@@ -22,6 +22,24 @@ prebuilt_swift_static_framework(
 If you omit `srcs`, this macro defaults to `Sources/**/*.swift`. This
 macro doesn't currently support resources, but could be updated to do
 so. Internally this rule creates a `swift_library` and compiles it for
-all the architectures passed with `--ios_multi_cpus`. If you want to
-re-use this same `swift_library` you could make the
-`_prebuilt_swift_static_framework` public, and use it directly.
+all the architectures passed with `--ios_multi_cpus`.
+
+To build the framework you need to run `bazel build WhateverFramework`.
+Otherwise you build the underlying `swift_library`. This is so you can
+depend on the `swift_library` from other libraries with the name you
+defined.
+
+## Implementation
+
+This works by using bazel's `apple_common.multi_arch_split`
+configuration. This is used in rule's in place of `target` or `host` in
+the `cfg` field. When you use this you must provide both a
+`platform_type` which is a type of `apple_common.platform_type` and
+`minimum_os_version`.
+
+By using this attribute you now have `ctx.split_attr` populated in your
+rule's implementation. This field is a dictionary of architectures to
+the type of field where you set `cfg` to `multi_arch_split`. In the case
+of this rule we use this for `deps`, this way we have our single
+dependency grouped by architecture, and we can extract values that are
+architecture specific from it, such as the swiftmodule files.

--- a/prebuilt_swift_static_framework/prebuilt_swift_static_framework.bzl
+++ b/prebuilt_swift_static_framework/prebuilt_swift_static_framework.bzl
@@ -22,7 +22,7 @@ def _zip_swift_arg(module_name, swift_identifier, input_file):
     )
 
 def _prebuilt_swift_static_framework_impl(ctx):
-    module_name = ctx.label.name
+    module_name = ctx.attr.framework_name
     fat_file = ctx.outputs.fat_file
 
     input_archives = []
@@ -71,6 +71,7 @@ def _prebuilt_swift_static_framework_impl(ctx):
 _prebuilt_swift_static_framework = rule(
     implementation = _prebuilt_swift_static_framework_impl,
     attrs = {
+        "framework_name": attr.string(mandatory = True),
         "deps": attr.label_list(
             mandatory = True,
             providers = [SwiftInfo],
@@ -94,15 +95,15 @@ _prebuilt_swift_static_framework = rule(
 
 def prebuilt_swift_static_framework(name, srcs = [], deps = []):
     srcs = srcs or native.glob(["Sources/**/*.swift"])
-    library_name = name + "Library"
     swift_library(
-        name = library_name,
+        name = name,
         module_name = name,
         srcs = srcs,
         deps = deps,
     )
 
     _prebuilt_swift_static_framework(
-        name = name,
-        deps = [":" + library_name],
+        name = name + "Framework",
+        framework_name = name,
+        deps = [":" + name],
     )

--- a/prebuilt_swift_static_framework/prebuilt_swift_static_framework.bzl
+++ b/prebuilt_swift_static_framework/prebuilt_swift_static_framework.bzl
@@ -1,0 +1,108 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "swift_library")
+
+_PLATFORM_TO_SWIFTMODULE = {
+    "ios_armv7": "arm",
+    "ios_arm64": "arm64",
+    "ios_i386": "i386",
+    "ios_x86_64": "x86_64",
+}
+
+def _zip_binary_arg(module_name, input_file):
+    return "{module_name}.framework/{module_name}={file_path}".format(
+        module_name = module_name,
+        file_path = input_file.path,
+    )
+
+def _zip_swift_arg(module_name, swift_identifier, input_file):
+    return "{module_name}.framework/Modules/{module_name}.swiftmodule/{swift_identifier}.{ext}={file_path}".format(
+        module_name = module_name,
+        swift_identifier = swift_identifier,
+        ext = input_file.extension,
+        file_path = input_file.path,
+    )
+
+def _prebuilt_swift_static_framework_impl(ctx):
+    module_name = ctx.label.name
+    fat_file = ctx.outputs.fat_file
+
+    input_archives = []
+    input_modules_docs = []
+    zip_args = [_zip_binary_arg(module_name, fat_file)]
+
+    for platform, deps in ctx.split_attr.deps.items():
+        swiftmodule_identifier = _PLATFORM_TO_SWIFTMODULE[platform]
+        swift_info = deps[0][SwiftInfo]
+        archive = swift_info.direct_libraries[0]
+        swiftdoc = swift_info.direct_swiftdocs[0]
+        swiftmodule = swift_info.direct_swiftmodules[0]
+
+        input_archives.append(archive)
+        input_modules_docs += [swiftdoc, swiftmodule]
+        zip_args += [
+            _zip_swift_arg(module_name, swiftmodule_identifier, swiftdoc),
+            _zip_swift_arg(module_name, swiftmodule_identifier, swiftmodule),
+        ]
+
+    ctx.actions.run(
+        inputs = input_archives,
+        outputs = [fat_file],
+        mnemonic = "LipoSwiftLibraries",
+        progress_message = "Combining libraries for {}".format(module_name),
+        executable = "lipo",
+        arguments = ["-create", "-output", fat_file.path] + [x.path for x in input_archives],
+    )
+
+    output_zip = ctx.outputs.output_zip
+    ctx.actions.run(
+        inputs = input_modules_docs + [fat_file],
+        outputs = [output_zip],
+        mnemonic = "CreateSwiftFrameworkZip",
+        progress_message = "Creating framework zip for {}".format(module_name),
+        executable = ctx.executable._zipper,
+        arguments = ["c", output_zip.path] + zip_args,
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([output_zip]),
+        ),
+    ]
+
+_prebuilt_swift_static_framework = rule(
+    implementation = _prebuilt_swift_static_framework_impl,
+    attrs = {
+        "deps": attr.label_list(
+            mandatory = True,
+            providers = [SwiftInfo],
+            cfg = apple_common.multi_arch_split,
+        ),
+        "platform_type": attr.string(
+            default = str(apple_common.platform_type.ios),
+        ),
+        "minimum_os_version": attr.string(default = "10.0"),
+        "_zipper": attr.label(
+            default = "@bazel_tools//tools/zip:zipper",
+            cfg = "host",
+            executable = True,
+        ),
+    },
+    outputs = {
+        "fat_file": "%{name}.fat",
+        "output_zip": "%{name}.zip",
+    },
+)
+
+def prebuilt_swift_static_framework(name, srcs = [], deps = []):
+    srcs = srcs or native.glob(["Sources/**/*.swift"])
+    library_name = name + "Library"
+    swift_library(
+        name = library_name,
+        module_name = name,
+        srcs = srcs,
+        deps = deps,
+    )
+
+    _prebuilt_swift_static_framework(
+        name = name,
+        deps = [":" + library_name],
+    )


### PR DESCRIPTION
This rule lets you build a fat static framework from Swift sources