### PR TITLE
Add bazelwrapper to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tools/.xcode_select_env

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -25,7 +25,6 @@ BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"
 BAZEL_PATH="$BAZEL_ROOT/bin/bazel"
 XCODE_SELECT_ENV_PATH="${SCRIPTPATH}/.xcode_select_env"
-LEGACY_BAZEL_PATH="$SCRIPTPATH/../Scripts/bazel/bin/bazel"
 
 BAZEL=""
 
@@ -47,8 +46,6 @@ function install_bazel() {
 # Lastly, check if there is one installed on the path
 if [[ -e "$BAZEL_PATH" ]]; then
   BAZEL="$BAZEL_PATH"
-elif [[ -e "$LEGACY_BAZEL_PATH" ]] && [[ $("$LEGACY_BAZEL_PATH" version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
-  BAZEL="$LEGACY_BAZEL_PATH"
 elif [[ -e $(which bazel) ]] && [[ $($(which bazel) version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
   BAZEL=$(which bazel)
 fi

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# bazelwrapper
+# A script to sit between your scripts and bazel and can be checked into your
+# repository. Bazel moves quickly and is not always backwards compatible so the
+# version of bazel each commit builds with is important to preserve history.
+# This script can update bazel version by modifying the BAZEL_VERSION,
+# BAZEL_VERSION_SHA below to the desired release
+# (https://github.com/bazelbuild/bazel/releases)
+
+set -e
+
+# Make sure we're in the project root directory.
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+pushd "$SCRIPTPATH/.." > /dev/null
+trap popd > /dev/null ERR EXIT
+
+# Go to bazel release page
+# These are typically posted in groups.google
+# https://groups.google.com/forum/#!forum/bazel-discuss
+BAZEL_VERSION="0.19.2"
+BAZEL_VERSION_SHA="25ea85d4974ead87a7600e17b733bf8035a075fc8671c97e1c1f7dc8ff304231"
+BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
+
+BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"
+BAZEL_PATH="$BAZEL_ROOT/bin/bazel"
+XCODE_SELECT_ENV_PATH="${SCRIPTPATH}/.xcode_select_env"
+LEGACY_BAZEL_PATH="$SCRIPTPATH/../Scripts/bazel/bin/bazel"
+
+BAZEL=""
+
+function install_bazel() {
+    curl -L "$BAZEL_VERSION_URL" > $PWD/install_bazel.sh
+    SHA=$(shasum -a 256 install_bazel.sh | awk '{ print $1 }')
+    if [[ $SHA == $BAZEL_VERSION_SHA ]]; then
+        chmod +x install_bazel.sh
+        $PWD/install_bazel.sh --prefix="$BAZEL_ROOT" && rm install_bazel.sh
+    else
+        echo "You version of bazel is out of date; ask for help in #cx-ios"
+        exit 1
+    fi
+}
+
+# Check if we have the correct version of bazel installed in the home
+# directory.
+# Fallback to ./Scripts/bazel/bin/bazel for legacy installations
+# Lastly, check if there is one installed on the path
+if [[ -e "$BAZEL_PATH" ]]; then
+  BAZEL="$BAZEL_PATH"
+elif [[ -e "$LEGACY_BAZEL_PATH" ]] && [[ $("$LEGACY_BAZEL_PATH" version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
+  BAZEL="$LEGACY_BAZEL_PATH"
+elif [[ -e $(which bazel) ]] && [[ $($(which bazel) version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
+  BAZEL=$(which bazel)
+fi
+
+# Ensure we can execute the path for bazel and that it's the correct version
+if ! [[ -e "$BAZEL" ]]; then
+  echo "WARNING: Missing installation or incorrect bazel version (expecting $BAZEL_VERSION)" >&2;
+  echo "Installing Bazel $BAZEL_VERSION to $BAZEL_PATH" >&2;
+  install_bazel
+  BAZEL=$BAZEL_PATH
+fi
+
+if [[ -x "${BAZEL}" ]]; then
+  CURRENT_XCODE_PATH="$(/usr/bin/xcode-select -p)"
+  XCODE_VERSION=$(/usr/bin/xcodebuild -version | grep Xcode | cut -d ' ' -f2)
+  CURRENT_XCODE_HASH="${CURRENT_XCODE_PATH}-${XCODE_VERSION}-${BAZEL_VERSION}"
+  if [[ -f "${XCODE_SELECT_ENV_PATH}" ]]; then
+    EXISTING_XCODE_HASH="$(cat "${XCODE_SELECT_ENV_PATH}")"
+    if [[ $EXISTING_XCODE_HASH != $CURRENT_XCODE_HASH ]]; then
+      echo "Xcode select path or Bazel version has changed, must clear cached data"
+      $BAZEL clean --expunge
+    fi
+  fi
+  echo "${CURRENT_XCODE_HASH}" > $XCODE_SELECT_ENV_PATH
+
+  # Make variable support
+  # In the context of Xcode builds, variables are defined as "Make variable"
+  # strings.
+  # In practice, the variables are stored as strings, and then later assigned to
+  # the value of the current environment.
+  ARGS=()
+  for ARG in "$@"; do
+      if [[ "$ARG" =~ \$(.*) ]]; then
+        # Get the name of the make variable
+        MAKEVAR=$(echo $ARG | sed 's,.*\$(\(.*\)).*,\1,g')
+        # Next, parameter expansion of the variable by name
+        VALUE="${!MAKEVAR}"
+        REPLACED="$(echo $ARG | sed "s,\$(\(.*\)),$VALUE,g")"
+        ARGS+=(${REPLACED})
+      else
+        ARGS+=("${ARG}")
+      fi
+  done
+
+  exec -a "$0" /usr/bin/env - TERM=$TERM SHELL=$SHELL PATH=$PATH HOME=$HOME "${BAZEL}" "${ARGS[@]}"
+else
+  echo "WARNING: Missing installation of bazel" >&2;
+  exit 1
+fi

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -5,10 +5,10 @@
 # repository. Bazel moves quickly and is not always backwards compatible so the
 # version of bazel each commit builds with is important to preserve history.
 # This script can update bazel version by modifying the BAZEL_VERSION,
-# BAZEL_VERSION_SHA below to the desired release
+# BAZEL_VERSION_SHA below to the desired release (linux and darwin)
 # (https://github.com/bazelbuild/bazel/releases)
 
-set -e
+set -euo pipefail
 
 # Make sure we're in the project root directory.
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
@@ -19,8 +19,15 @@ trap popd > /dev/null ERR EXIT
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
 BAZEL_VERSION="0.19.2"
-BAZEL_VERSION_SHA="25ea85d4974ead87a7600e17b733bf8035a075fc8671c97e1c1f7dc8ff304231"
-BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
+if [[ $OSTYPE == darwin* ]]; then
+    TARGET_PLATFORM="darwin"
+    BAZEL_VERSION_SHA="25ea85d4974ead87a7600e17b733bf8035a075fc8671c97e1c1f7dc8ff304231"
+else
+    TARGET_PLATFORM="linux"
+    BAZEL_VERSION_SHA="42ba631103011594cdf5591ef07658a9e9a5d73c5ee98a9f09651ac4ac535d8c"
+fi
+
+BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${TARGET_PLATFORM}-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"
 BAZEL_PATH="$BAZEL_ROOT/bin/bazel"
@@ -35,7 +42,9 @@ function install_bazel() {
         chmod +x install_bazel.sh
         $PWD/install_bazel.sh --prefix="$BAZEL_ROOT" && rm install_bazel.sh
     else
-        echo "You version of bazel is out of date; ask for help in #cx-ios"
+        echo "Bazel version does not match expected shasum"
+        echo "Expected: ${BAZEL_VERSION_SHA}"
+        echo "Actual: ${SHA}"
         exit 1
     fi
 }
@@ -52,7 +61,7 @@ fi
 
 # Ensure we can execute the path for bazel and that it's the correct version
 if ! [[ -e "$BAZEL" ]]; then
-  echo "WARNING: Missing installation or incorrect bazel version (expecting $BAZEL_VERSION)" >&2;
+  echo "WARNING: Missing installation bazel (expecting version $BAZEL_VERSION)" >&2;
   echo "Installing Bazel $BAZEL_VERSION to $BAZEL_PATH" >&2;
   install_bazel
   BAZEL=$BAZEL_PATH
@@ -90,8 +99,9 @@ if [[ -x "${BAZEL}" ]]; then
       fi
   done
 
-  exec -a "$0" /usr/bin/env - TERM=$TERM SHELL=$SHELL PATH=$PATH HOME=$HOME "${BAZEL}" "${ARGS[@]}"
+  # Run Bazel Invocation
+  exec "${BAZEL}" "$@"
 else
-  echo "WARNING: Missing installation of bazel" >&2;
+  echo "WARNING: Missing installation of bazel (version ${BAZEL_VERSION})" >&2;
   exit 1
 fi


### PR DESCRIPTION
- Allows you to check in the version of bazel each commit builds against
- Maintains multiple installations of Bazel under $HOME/.bazelenv
- Automatically runs "bazel clean --expunge" if the version of Xcode has
  changed