### PR TITLE
Remove genrule_strategy

### DIFF
--- a/UsefulFlags.md
+++ b/UsefulFlags.md
@@ -93,10 +93,6 @@ By default, Bazel has a serial queue for generating digests for build actions (h
 
 Disable sandboxing for spawn actions. This is required for remote caching.
 
-###### `--genrule_strategy=standalone`
-
-Disable sandboxing for genrule actions. This is required for remote caching.
-
 #### Local
 
 ###### `--disk_cache=/path/to/disk/cache`


### PR DESCRIPTION
This flag is deprecated and implied by spawn_strategy

From the docs https://docs.bazel.build/versions/master/command-line-reference.html:

>Specify how to execute genrules. This flag will be phased out.
Instead, use -- spawn_strategy=<value> to control all actions or
--strategy=Genrule=< value> to control genrules only.