### PR TITLE
Add `Framework` suffix to name of the output fat file and zip file

### DIFF
--- a/prebuilt_swift_static_framework/prebuilt_swift_static_framework.bzl
+++ b/prebuilt_swift_static_framework/prebuilt_swift_static_framework.bzl
@@ -88,8 +88,8 @@ _prebuilt_swift_static_framework = rule(
         ),
     ),
     outputs = {
-        "fat_file": "%{framework_name}.fat",
-        "output_file": "%{framework_name}.zip",
+        "fat_file": "%{name}.fat",
+        "output_file": "%{name}.zip",
     },
 )
 


### PR DESCRIPTION
Previously the output filename was `WhateverFramework.zip`.
With the changes in #19, it was change too `Whatever.zip`.
This changes that back.