### PR TITLE
Generate modulemap file and include it in the framework bundle

### DIFF
--- a/swift_static_framework/swift_static_framework.bzl
+++ b/swift_static_framework/swift_static_framework.bzl
@@ -41,11 +41,11 @@ def _zip_modulemap_arg(module_name, modulemap_file):
 
 def _modulemap_file_content(module_name):
     return """\
-framework module %s {
-  header %s-Swift.h
+framework module {module_name} {{
+  header {module_name}-Swift.h
   requires objc
-}
-""" % (module_name, module_name)
+}}
+""".format(module_name = module_name)
 
 def _swift_static_framework_impl(ctx):
     module_name = ctx.attr.module_name

--- a/swift_static_framework/swift_static_framework.bzl
+++ b/swift_static_framework/swift_static_framework.bzl
@@ -33,9 +33,16 @@ def _zip_generated_objc_hdr_arg(module_name, generated_objc_hdr_file):
         file_path = generated_objc_hdr_file.path,
     )
 
+def _zip_modulemap_arg(module_name, modulemap_file):
+    return "{module_name}.framework/Modules/module.modulemap={file_path}".format(
+        module_name = module_name,
+        file_path = modulemap_file.path,
+    )
+
 def _swift_static_framework_impl(ctx):
     module_name = ctx.attr.module_name
     fat_file = ctx.outputs.fat_file
+    modulemap_file = ctx.outputs.modulemap_file
     zip_args = [_zip_binary_arg(module_name, fat_file)]
 
     libraries = []
@@ -90,8 +97,24 @@ def _swift_static_framework_impl(ctx):
 
     input_files = [fat_file]
     if generated_objc_hdr_file:
+        modulemap_file_content = """\
+framework module %s {
+  header %s-Swift.h
+  requires objc
+}
+""" % (module_name, module_name)
+
+        ctx.actions.write(
+            output = modulemap_file,
+            content = modulemap_file_content
+        )
+        zip_args.append(_zip_modulemap_arg(module_name, modulemap_file))
+
         input_files.append(generated_objc_hdr_file)
+        input_files.append(modulemap_file)
+
     output_file = ctx.outputs.output_file
+
     ctx.actions.run(
         inputs = swift_info_files + input_files,
         outputs = [output_file],
@@ -130,6 +153,7 @@ _swift_static_framework = rule(
     fragments = ["apple"],
     outputs = {
         "fat_file": "%{name}.fat",
+        "modulemap_file": "module.modulemap",
         "output_file": "%{name}.zip",
     },
 )
@@ -164,6 +188,7 @@ def swift_static_framework(name, srcs = [], deps = [], **kwargs):
     testonly = kwargs.get("testonly", False)
     minimum_os_version = kwargs.get("minimum_os_version", _DEFAULT_MINIMUM_OS_VERSION)
     visibility = kwargs.get("visibility")
+
     swift_library(
         name = name,
         testonly = testonly,

--- a/swift_static_framework/swift_static_framework.bzl
+++ b/swift_static_framework/swift_static_framework.bzl
@@ -39,6 +39,14 @@ def _zip_modulemap_arg(module_name, modulemap_file):
         file_path = modulemap_file.path,
     )
 
+def _modulemap_file_content(module_name):
+    return """\
+framework module %s {
+  header %s-Swift.h
+  requires objc
+}
+""" % (module_name, module_name)
+
 def _swift_static_framework_impl(ctx):
     module_name = ctx.attr.module_name
     fat_file = ctx.outputs.fat_file
@@ -97,16 +105,9 @@ def _swift_static_framework_impl(ctx):
 
     input_files = [fat_file]
     if generated_objc_hdr_file:
-        modulemap_file_content = """\
-framework module %s {
-  header %s-Swift.h
-  requires objc
-}
-""" % (module_name, module_name)
-
         ctx.actions.write(
             output = modulemap_file,
-            content = modulemap_file_content
+            content = _modulemap_file_content(module_name)
         )
         zip_args.append(_zip_modulemap_arg(module_name, modulemap_file))
 


### PR DESCRIPTION
Swift generated header file exists. This allows the final framework to
be consumable from Objective-C.